### PR TITLE
fix-xdebug

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -12,6 +12,7 @@ FROM development AS debug
 
 RUN apk add --update --no-cache --virtual .builddeps gcc libc-dev autoconf && \
     pecl install xdebug && \
+    docker-php-ext-enable xdebug && \
     apk del .builddeps
 
 COPY php.ini /usr/local/etc/php/conf.d/xdebug.ini

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,5 +1,5 @@
 [xdebug]
-zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so
+zend_extension=/usr/local/lib/php/extensions/no-debug-non-zts-20190902/xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_autostart=1
 xdebug.remote_port=9000


### PR DESCRIPTION
- rel. https://github.com/tamakiii-sandbox/hello-symfony-5.0/pull/1

~~~sh
$ docker-compose run --rm php ash
/project # ls -lsa /usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so
ls: /usr/local/lib/php/extensions/no-debug-non-zts-20170718/xdebug.so: No such file or directory
/project # ls -lsa /usr/local/lib/php/extensions/no-debug-non-zts-20170718
ls: /usr/local/lib/php/extensions/no-debug-non-zts-20170718: No such file or directory
~~~